### PR TITLE
fix bug:  one extra brackets in g:defx_git#indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ let g:defx_git#indicators = {
   \ 'Ignored'   : '☒',
   \ 'Deleted'   : '✖',
   \ 'Unknown'   : '?'
-  \ })
+  \ }
 ```
 
 ### g:defx_git#column_length


### PR DESCRIPTION
fix bug:  one extra brackets in g:defx_git#indicators