### PR TITLE
Indicator char width setting

### DIFF
--- a/ftplugin/defx.vim
+++ b/ftplugin/defx.vim
@@ -19,6 +19,7 @@ let g:defx_git#indicators = get(g:, 'defx_git#indicators', {
 let g:defx_git#column_length = get(g:, 'defx_git#column_length', 1)
 let g:defx_git#show_ignored = get(g:, 'defx_git#show_ignored', 0)
 let g:defx_git#raw_mode = get(g:, 'defx_git#raw_mode', 0)
+let g:defx_git#indicatorWidth = get(g:, 'defx_git#indicatorWidth', 2)
 
 let s:icons = join(values(g:defx_git#indicators), '\|')
 

--- a/rplugin/python3/defx/column/git.py
+++ b/rplugin/python3/defx/column/git.py
@@ -23,6 +23,7 @@ class Column(Base):
         self.indicators = self.vim.vars['defx_git#indicators']
         self.show_ignored = self.vim.vars['defx_git#show_ignored']
         self.raw_mode = self.vim.vars['defx_git#raw_mode']
+        self.indicatorWidth = self.vim.vars['defx_git#indicatorWidth']
         self.colors = {
             'Modified': {
                 'color': 'guifg=#fabd2f ctermfg=214',

--- a/rplugin/python3/defx/column/git.py
+++ b/rplugin/python3/defx/column/git.py
@@ -62,7 +62,7 @@ class Column(Base):
                                  self.vim.vars['defx_git#column_length'])
 
     def get(self, context: Context, candidate: dict) -> str:
-        default = self.format('')
+        default = self.format('').ljust(self.column_length + self.indicatorWidth - 1)
         if candidate.get('is_root', False):
             self.cache_status(candidate['action__path'])
             return default


### PR DESCRIPTION
![2019-07-20 1 02 25](https://user-images.githubusercontent.com/3665531/61549467-0904db00-aa8b-11e9-95a0-90cbf2416b2f.png)

If you set the indicator icon to double width char, the indent of items without an indicator icon will break.
If this plug-in can set the width of the indicator icon, this problem is solved.

#### config sample
![2019-07-20 1 21 50](https://user-images.githubusercontent.com/3665531/61550199-d2c85b00-aa8c-11e9-8a05-b5615348de4d.png)

