### PR TITLE
Use defx internal custom option system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # defx-git
+
 Git status implementation for [defx.nvim](http://github.com/Shougo/defx.nvim).
 
 ## Usage
+
 Just append `git` to your columns when starting defx:
-```
+
+```viml
 :Defx -columns=git:mark:filename:type
 ```
 
 ## Options
+
 ### Indicators
 
 Which indicators (icons) to use for each status. These are the defaults:
-```vimL
+
+```viml
 call defx#custom#column('git', 'indicators', {
   \ 'Modified'  : '✹',
   \ 'Staged'    : '✚',
@@ -24,12 +29,14 @@ call defx#custom#column('git', 'indicators', {
   \ })
 ```
 
-### Column-length
+### Column Length
 
 How many space should git column take. Default is `1` (Defx adds a single space between columns):
-```vimL
+
+```viml
 call defx#custom#column('git', 'column_length', 1)
 ```
+
 Missing characters to match this length are populated with spaces, which means
 `✹` becomes `✹ `, etc.
 
@@ -39,23 +46,32 @@ Note: Make sure indicators are not longer than the column_length
 
 This flag determines if ignored files should be marked with indicator. Default is `false`:
 
-```vimL
+```viml
 call defx#custom#column('git', 'show_ignored', 0)
 ```
 
-### Raw mode
+### Raw Mode
 
 Show git status in raw mode (Same as first two chars of `git status --porcelain` command). Default is `0`:
 
-```vimL
+```viml
 call defx#custom#column('git', 'raw_mode', 0)
+```
+
+### Max Indicator Width
+
+The number of characters to pad the git column. If not specified, the default
+will be the width of the longest indicator character.
+
+```viml
+call defx#custom#column('git', 'max_indicator_width', 2)
 ```
 
 ## Highlighting
 
 Each indicator type can be overridden with the custom highlight. These are the defaults:
 
-```vimL
+```viml
 hi Defx_git_Untracked guibg=NONE guifg=NONE ctermbg=NONE ctermfg=NONE
 hi Defx_git_Ignored guibg=NONE guifg=NONE ctermbg=NONE ctermfg=NONE
 hi Defx_git_Unknown guibg=NONE guifg=NONE ctermbg=NONE ctermfg=NONE
@@ -68,7 +84,7 @@ hi Defx_git_Staged ctermfg=142 guifg=#b8bb26
 
 To use for example red for untracked files, add this **after** your colorscheme setup:
 
-```vimL
+```viml
 colorscheme gruvbox
 hi Defx_git_Untracked guifg=#FF0000
 ```
@@ -76,12 +92,13 @@ hi Defx_git_Untracked guifg=#FF0000
 ## Mappings
 
 There are two mappings:
+
 * `<Plug>(defx-git-next)` - Goes to the next file that has a git status
-* `<Plug>(defx-git-prev)` - Goes to the prev file that has a git status
+* `<Plug>(defx-git-prev)` - Goes to the previous file that has a git status
 
 If these are not manually mapped by the user, defaults are:
 
-```vimL
+```viml
 nnoremap <buffer><silent> [c <Plug>(defx-git-prev)
 nnoremap <buffer><silent> ]c <Plug>(defx-git-next)
 ```

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Just append `git` to your columns when starting defx:
 ```
 
 ## Options
-### g:defx_git#indicators
+### Indicators
 
 Which indicators (icons) to use for each status. These are the defaults:
 ```vimL
-let g:defx_git#indicators = {
+call defx#custom#column('git', 'indicators', {
   \ 'Modified'  : '✹',
   \ 'Staged'    : '✚',
   \ 'Untracked' : '✭',
@@ -21,34 +21,34 @@ let g:defx_git#indicators = {
   \ 'Ignored'   : '☒',
   \ 'Deleted'   : '✖',
   \ 'Unknown'   : '?'
-  \ }
+  \ })
 ```
 
-### g:defx_git#column_length
+### Column-length
 
 How many space should git column take. Default is `1` (Defx adds a single space between columns):
 ```vimL
-let g:defx_git#column_length = 1
+call defx#custom#column('git', 'column_length', 1)
 ```
 Missing characters to match this length are populated with spaces, which means
 `✹` becomes `✹ `, etc.
 
 Note: Make sure indicators are not longer than the column_length
 
-### g:defx_git#show_ignored
+### Show ignored
 
 This flag determines if ignored files should be marked with indicator. Default is `false`:
 
 ```vimL
-let g:defx_git#show_ignored = 0
+call defx#custom#column('git', 'show_ignored', 0)
 ```
 
-### g:defx_git#raw_mode
+### Raw mode
 
 Show git status in raw mode (Same as first two chars of `git status --porcelain` command). Default is `0`:
 
 ```vimL
-let g:defx_git#raw_mode = 1
+call defx#custom#column('git', 'raw_mode', 0)
 ```
 
 ## Highlighting

--- a/ftplugin/defx.vim
+++ b/ftplugin/defx.vim
@@ -5,30 +5,15 @@ endif
 
 let b:defx_git_loaded = 1
 
-let g:defx_git#indicators = get(g:, 'defx_git#indicators', {
-      \ 'Modified'  : '✹',
-      \ 'Staged'    : '✚',
-      \ 'Untracked' : '✭',
-      \ 'Renamed'   : '➜',
-      \ 'Unmerged'  : '═',
-      \ 'Ignored'   : '☒',
-      \ 'Deleted'   : '✖',
-      \ 'Unknown'   : '?'
-      \ })
-
-let g:defx_git#column_length = get(g:, 'defx_git#column_length', 1)
-let g:defx_git#show_ignored = get(g:, 'defx_git#show_ignored', 0)
-let g:defx_git#raw_mode = get(g:, 'defx_git#raw_mode', 0)
-
-if !exists('g:defx_git#indicator_width')
-  let g:defx_git#max_indicator_width = max(map(copy(g:defx_git#indicators), 'strwidth(v:val)'))
-endif
-
-let s:icons = join(values(g:defx_git#indicators), '\|')
-
 function! s:search(dir) abort
-  let l:direction = a:dir > 0 ? 'w' : 'bw'
-  return search(printf('\(%s\)', s:icons), l:direction)
+  let l:column_opts = defx#custom#_get().column
+  let l:icons = get(get(l:column_opts, 'git', {}), 'indicators', {})
+  let l:icons_pattern = join(values(l:icons), '\|')
+
+  if !empty(l:icons_pattern)
+    let l:direction = a:dir > 0 ? 'w' : 'bw'
+    return search(printf('\(%s\)', l:icons_pattern), l:direction)
+  endif
 endfunction
 
 nnoremap <buffer><silent><Plug>(defx-git-next) :<C-u>call <sid>search(1)<CR>

--- a/rplugin/python3/defx/column/git.py
+++ b/rplugin/python3/defx/column/git.py
@@ -19,7 +19,7 @@ class Column(Base):
 
         self.name = 'git'
         self.vars = {
-            'indicators': {
+            'indicators': self.vim.vars.get('defx_git#indicators', {
                 'Modified': '✹',
                 'Staged': '✚',
                 'Untracked': '✭',
@@ -28,14 +28,13 @@ class Column(Base):
                 'Ignored': '☒',
                 'Deleted': '✖',
                 'Unknown': '?'
-            },
-            'column_length': 1,
-            'show_ignored': False,
-            'raw_mode': False,
+            }),
+            'column_length': self.vim.vars.get('defx_git#column_length', 1),
+            'show_ignored': self.vim.vars.get('defx_git#show_ignored', False),
+            'raw_mode': self.vim.vars.get('defx_git#raw_mode', False),
+            'max_indicator_width': self.vim.vars.get(
+                'defx_git#max_indicator_width', None)
         }
-
-        self.vars['max_indicator_width'] = len(
-            max(self.vars['indicators'].values(), key=len))
 
         self.cache: typing.List[str] = []
         self.git_root = ''
@@ -75,6 +74,11 @@ class Column(Base):
         }
         min_column_length = 2 if self.vars['raw_mode'] else 1
         self.column_length = max(min_column_length, self.vars['column_length'])
+
+    def on_init(self, context: Context) -> None:
+        if not self.vars.get('max_indicator_width'):
+            self.vars['max_indicator_width'] = len(
+                max(self.vars['indicators'].values(), key=len))
 
     def get(self, context: Context, candidate: dict) -> str:
         default = self.format('').ljust(

--- a/rplugin/python3/defx/column/git.py
+++ b/rplugin/python3/defx/column/git.py
@@ -18,12 +18,27 @@ class Column(Base):
         super().__init__(vim)
 
         self.name = 'git'
+        self.vars = {
+            'indicators': {
+                'Modified': '✹',
+                'Staged': '✚',
+                'Untracked': '✭',
+                'Renamed': '➜',
+                'Unmerged': '═',
+                'Ignored': '☒',
+                'Deleted': '✖',
+                'Unknown': '?'
+            },
+            'column_length': 1,
+            'show_ignored': False,
+            'raw_mode': False,
+        }
+
+        self.vars['max_indicator_width'] = len(
+            max(self.vars['indicators'].values(), key=len))
+
         self.cache: typing.List[str] = []
         self.git_root = ''
-        self.indicators = self.vim.vars['defx_git#indicators']
-        self.max_indicator_width = self.vim.vars['defx_git#max_indicator_width']
-        self.show_ignored = self.vim.vars['defx_git#show_ignored']
-        self.raw_mode = self.vim.vars['defx_git#raw_mode']
         self.colors = {
             'Modified': {
                 'color': 'guifg=#fabd2f ctermfg=214',
@@ -58,12 +73,12 @@ class Column(Base):
                 'match': 'X '
             }
         }
-        min_column_length = 2 if self.raw_mode else 1
-        self.column_length = max(min_column_length,
-                                 self.vim.vars['defx_git#column_length'])
+        min_column_length = 2 if self.vars['raw_mode'] else 1
+        self.column_length = max(min_column_length, self.vars['column_length'])
 
     def get(self, context: Context, candidate: dict) -> str:
-        default = self.format('').ljust(self.column_length + self.max_indicator_width - 1)
+        default = self.format('').ljust(
+            self.column_length + self.vars['max_indicator_width'] - 1)
         if candidate.get('is_root', False):
             self.cache_status(candidate['action__path'])
             return default
@@ -79,23 +94,25 @@ class Column(Base):
         return self.get_indicator(entry)
 
     def get_indicator(self, entry: str) -> str:
-        if self.raw_mode:
+        if self.vars['raw_mode']:
             return self.format(entry[:2])
 
+        state = self.get_indicator_name(entry[0], entry[1])
         return self.format(
-            self.indicators[self.get_indicator_name(entry[0], entry[1])]
+            self.vars['indicators'][state]
         )
 
     def length(self, context: Context) -> int:
         return self.column_length
 
     def syntaxes(self) -> typing.List[str]:
-        return [self.syntax_name + '_' + name for name in self.indicators]
+        return [
+            self.syntax_name + '_' + name for name in self.vars['indicators']]
 
     def highlight_commands(self) -> typing.List[str]:
         commands: typing.List[str] = []
-        for name, icon in self.indicators.items():
-            if self.raw_mode:
+        for name, icon in self.vars['indicators'].items():
+            if self.vars['raw_mode']:
                 commands.append((
                     'syntax match {0}_{1} /{2}/ contained containedin={0}'
                 ).format(self.syntax_name, name, self.colors[name]['match']))
@@ -134,7 +151,7 @@ class Column(Base):
             return None
 
         cmd = ['git', 'status', '--porcelain', '-u']
-        if self.show_ignored:
+        if self.vars['show_ignored']:
             cmd += ['--ignored']
 
         status = self.run_cmd(cmd, self.git_root)


### PR DESCRIPTION
This patch normalizes defx-git options to use defx's internal column options.
It also avoids "Key not found" errors when reloading vimrc within vim:
```
Error detected while processing function dein#autoload#_on_cmd[13]..defx#util#call_defx[2]..defx#start[5]..defx#util#rpcrequest:
line   18:
Error invoking '_defx_start' on channel 5 (python3-rplugin-host):^@error caught in request handler '_defx_start [[[], {'columns': 'indent:git:icons:filename', 'auto_cd':
 0, 'prev_bufnr': 1, 'root_marker': '[in]: ', 'resume': 1, 'auto_recursive_level': 0, 'sort': 'filename', 'listed': 1, 'new': 0, 'ignored_files': '.mypy_cache,.pytest_ca
che,.git,.hg,.svn,.stversions,__pycache__,.sass-cache,*.egg-info,.DS_Store,*.pyc', 'direction': 'topleft', 'visual_end': 0, 'winheight': 30, 'profile': 0, 'search': '',
'buffer_name': 'tab1', 'winwidth': 25, 'split': 'vertical', 'visual_start': 0, 'cursor': 181, 'winrelative': 'editor', 'prev_winid': 1000, 'wincol': 42, 'winrow': 15, 's
ession_file': '', 'show_ignored_files': 0, 'toggle': 1}]]':^@Traceback (most recent call last):^@  File "/Users/rafi/.cache/vim/dein/repos/github.com/Shougo/defx.n
vim/rplugin/python3/defx/__init__.py", line 36, in start^@    self._rplugin.start(args)^@  File "/Users/rafi/.cache/vim/dein/repos/github.com/Shougo/defx.nvim/rplu
gin/python3/defx/rplugin.py", line 32, in start^@    views[0].init(paths, context, self._clipboard)^@  File "/Users/rafi/.cache/vim/dein/repos/github.com/Shougo/de
fx.nvim/rplugin/python3/defx/view.py", line 51, in init^@    if not self._init_defx(paths, clipboard):^@  File "/Users/rafi/.cache/vim/dein/repos/github.com/Shougo
/defx.nvim/rplugin/python3/defx/view.py", line 379, in _init_defx^@    self._init_all_columns()^@  File "/Users/rafi/.cache/vim/dein/repos/github.com/Shougo/defx.n
vim/rplugin/python3/defx/view.py", line 473, in _init_all_columns^@    column = column(self._vim)^@  File "/Users/rafi/.cache/vim/dein/repos/github.com/kristijanhu
sak/defx-git/rplugin/python3/defx/column/git.py", line 23, in __init__^@    self.indicators = self.vim.vars['defx_git#indicators']^@  File "/Users/rafi/.cache/vim/
venv/neovim3/lib/python3.7/site-packages/pynvim/api/common.py", line 88, in __getitem__^@    return self._get(key)^@  File "/Users/rafi/.cache/vim/venv/neovim3/lib
/python3.7/site-packages/pynvim/api/nvim.py", line 182, in request^@    res = self._session.request(name, *args, **kwargs)^@  File "/Users/rafi/.cache/vim/venv/neo
vim3/lib/python3.7/site-packages/pynvim/msgpack_rpc/session.py", line 102, in request^@    raise self.error_wrapper(err)^@pynvim.api.nvim.NvimError: b'Key not found: def
x_git#indicators'
```
