### PR TITLE
Adds support for changing the commit to diff against

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Show git status in raw mode (Same as first two chars of `git status --porcelain`
 call defx#custom#column('git', 'raw_mode', 0)
 ```
 
+### Change git commit
+
+Change the git commit the files are diffed against (SHA-1, branchname, etc.). Default is `'HEAD'`:
+
+```viml
+call defx#custom#column('git', 'git_commit', 'HEAD')
+```
+
 ### Max Indicator Width
 
 The number of characters to pad the git column. If not specified, the default


### PR DESCRIPTION
This adds support to change the commit to diff against. So you can compare the current tree to other commits, branches tags etc.
I left the default codepath as is, because using `diff` needs 2 systemcalls instead of 1 to include untracked and ignored files. And there is no differentiation between ignored and untracked files.