### PR TITLE
bug fix

### DIFF
--- a/rplugin/python3/defx/column/git.py
+++ b/rplugin/python3/defx/column/git.py
@@ -23,9 +23,7 @@ class Column(Base):
         self.has_get_with_highlights = True
         self.vars = {
             'indicators': {
-                'Modified': '✹',
-                'Staged': '✚',
-                'Untracked': '✭',
+                'Modified': '✹', 'Staged': '✚', 'Untracked': '✭',
                 'Renamed': '➜',
                 'Unmerged': '═',
                 'Ignored': '☒',
@@ -160,7 +158,7 @@ class Column(Base):
             if item[0] == 'R':
                 item_path = item_path.split(' -> ')[1]
 
-            if item_path.startswith(path):
+            if item_path == path:
                 return item
 
         return ''


### PR DESCRIPTION
Hi! I came across a tiny issue like this.
![image](https://user-images.githubusercontent.com/44968921/127920245-86a6b421-c3f3-4be5-a00e-34b77a697574.png)
The binary file is in the .gitignore, but due to the compare using str.startswith() so it got indicate also. I change the compare just using regular ==. This work in my case, but I don't know if this will also work on other cases.